### PR TITLE
Update stm32f1_hal to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["no-std", "embedded", "usb"]
 vcell = "0.1.0"
 cortex-m = "0.6.0"
 stm32f0xx-hal = { version = "0.14", features = ["rt"], optional = true }
-stm32f1xx-hal = { version = "0.3", features = ["rt"], optional = true }
+stm32f1xx-hal = { version = "0.4", features = ["rt"], optional = true }
 stm32f3xx-hal = { version = "0.2", features = ["rt"], optional = true }
 stm32l4xx-hal = { version = "0.4", features = ["rt"], optional = true }
 usb-device = "0.2.0"


### PR DESCRIPTION
`stm32f1_hal` was bumped to 0.4.0 a few days ago so I figured this crate should use an update.

I don't have a project to test the functionality, but we haven't modified any USB things in the HAL, so I believe this should be safe to merge anyway